### PR TITLE
feat: batch actions for messages

### DIFF
--- a/proto/o5/dempe/v1/service.proto
+++ b/proto/o5/dempe/v1/service.proto
@@ -65,7 +65,7 @@ message GetMessageResponse {
 
 message MessageAction {
   string id = 1 [
-    (validate.rules).string.uuid = true
+    (buf.validate.field).string.uuid = true
   ];
 
   string note = 2;
@@ -87,7 +87,7 @@ message MessageAction {
 
 message MessageActionRequest {
   string message_id = 1 [
-    (validate.rules).string.uuid = true
+    (buf.validate.field).string.uuid = true
   ];
   string note = 2;
 
@@ -110,7 +110,7 @@ message MessageActionResponse {}
 
 message BatchMessageActionRequest {
   repeated string message_ids = 1 [
-    (validate.rules).string.uuid = true
+    (buf.validate.field).string.uuid = true
   ];
   string note = 2;
 

--- a/proto/o5/dempe/v1/service.proto
+++ b/proto/o5/dempe/v1/service.proto
@@ -64,6 +64,9 @@ message GetMessageResponse {
 }
 
 message MessageAction {
+  string id = 1 [
+    (validate.rules).string.uuid = true
+  ];
 
   string note = 2;
 
@@ -83,7 +86,9 @@ message MessageAction {
 }
 
 message MessageActionRequest {
-  string message_id = 1;
+  string message_id = 1 [
+    (validate.rules).string.uuid = true
+  ];
   string note = 2;
 
   oneof action {
@@ -104,7 +109,9 @@ message ActionEdit {
 message MessageActionResponse {}
 
 message BatchMessageActionRequest {
-  repeated string message_ids = 1;
+  repeated string message_ids = 1 [
+    (validate.rules).string.uuid = true
+  ];
   string note = 2;
 
   oneof action {

--- a/proto/o5/dempe/v1/service.proto
+++ b/proto/o5/dempe/v1/service.proto
@@ -20,7 +20,19 @@ service DempeService {
 
   rpc GetMessage(GetMessageRequest) returns (GetMessageResponse) {}
 
-  rpc MessageAction(MessageActionRequest) returns (MessageActionResponse) {}
+  rpc MessageAction(MessageActionRequest) returns (MessageActionResponse) {
+    option (google.api.http) = {
+      post: "/dempe/v1/messages/{message_id}/action"
+      body: "*"
+    };
+  }
+
+  rpc BatchMessageAction(BatchMessageActionRequest) returns (BatchMessageActionResponse) {
+    option (google.api.http) = {
+      post: "/dempe/v1/batch_messages/action"
+      body: "*"
+    };
+  }
 }
 
 message ListMessagesRequest {
@@ -44,7 +56,6 @@ message GetMessageRequest {
 
 message CapturedMessage {
   DeadMessage cause = 1;
-
 }
 
 message GetMessageResponse {
@@ -73,8 +84,13 @@ message MessageAction {
 
 message MessageActionRequest {
   string message_id = 1;
-  MessageAction action = 2;
+  string note = 2;
 
+  oneof action {
+    ActionDelete delete = 10;
+    ActionRequeue requeue = 11;
+    ActionEdit edit = 12;
+  }
 }
 
 message ActionDelete {}
@@ -86,3 +102,15 @@ message ActionEdit {
 }
 
 message MessageActionResponse {}
+
+message BatchMessageActionRequest {
+  repeated string message_ids = 1;
+  string note = 2;
+
+  oneof action {
+    ActionDelete delete = 10;
+    ActionRequeue requeue = 11;
+  }
+}
+
+message BatchMessageActionResponse {}


### PR DESCRIPTION
- Changed MessageActionRequest so the client doesn't need to send the timestamp or actor, I think the service should fill these.
- Added a BulkMessageAction endpoint, because I could see a usecase for wanting to perform a bulk delete or requeue.
- Added uuid validation for message id
- Added id to message action