### PR TITLE
stubbing deployer

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,10 +4,15 @@ deps:
   - remote: buf.build
     owner: bufbuild
     repository: protovalidate
-    commit: 63dfe56cc2c44cffa4815366ba7a99c0
-    digest: shake256:5a8a9856b92bf37171d45ccbe59fc48ea755cd682317b088cdf93e8e797ecf54039e012ece9a17084bb676e70c2e090296b2790782ebdbbedc7514e9b543e6bf
+    commit: 1baebb0a15184714854fa1ddfd22a29b
+    digest: shake256:ecd24ac37ca4f1ea65d816ae98e2a977e5004076ac957de9aedc0d4b517c66eaf3b7c8d6c7669ffd6e2eca5e8a5705372bed339ba47a608b37183ef1ee4f8baf
   - remote: buf.build
     owner: googleapis
     repository: googleapis
     commit: 28151c0d0a1641bf938a7672c500e01d
     digest: shake256:49215edf8ef57f7863004539deff8834cfb2195113f0b890dd1f67815d9353e28e668019165b9d872395871eeafcbab3ccfdb2b5f11734d3cca95be9e8d139de
+  - remote: buf.build
+    owner: pentops
+    repository: protoc-gen-listify
+    commit: 9207ab6bdd894c47a70b75c050ae230b
+    digest: shake256:53d6f9cca1ed04b2e42d07dbd6f0b4f05126ae5a0ea048489352bacd83c0fc473a552889fdb0cecd81e5b87dd7d9edae2388ffbc622882ecefcbdcac11782f58

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -4,6 +4,7 @@ name: buf.build/pentops/o5
 deps:
   - buf.build/googleapis/googleapis
   - buf.build/bufbuild/protovalidate
+  - buf.build/pentops/protoc-gen-listify
 
 
 lint:

--- a/proto/o5/deployer/v1/service/service.proto
+++ b/proto/o5/deployer/v1/service/service.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package o5.deployer.v1.service;
+
+import "google/api/annotations.proto";
+import "listify/v1/fields.proto";
+import "o5/deployer/v1/deployment.proto";
+
+option go_package = "github.com/pentops/o5-go/deployer/v1/deployer_pb";
+
+service DeploymentQueryService {
+  rpc GetDeployment(GetDeploymentRequest) returns (GetDeploymentResponse) {
+    option (google.api.http) = {
+      get: "/deployer/v1/deployment/{deployment_id}"
+    };
+  }
+
+  rpc ListDeploymentEvents(ListDeploymentEventsRequest) returns (ListDeploymentEventsResponse) {
+    option (google.api.http) = {
+      post: "/deployer/v1/deployment/{deployment_id}/events"
+      body: "*"
+    };
+  }
+
+  rpc ListDeployments(ListDeploymentsRequest) returns (ListDeploymentsResponse) {
+    option (google.api.http) = {
+      post: "/deployer/v1/deployments"
+      body: "*"
+    };
+  }
+}
+
+message GetDeploymentRequest {
+  string deployment_id = 1;
+}
+
+message GetDeploymentResponse {
+  o5.deployer.v1.DeploymentState deployment = 1;
+  ListDeploymentEventsResponse events = 2;
+}
+
+message ListDeploymentEventsRequest {
+  string deployment_id = 1;
+
+  listify.v1.PageRequest     page    = 100;
+  listify.v1.Search          search  = 101;
+  repeated listify.v1.Sort   sorts   = 102;
+  repeated listify.v1.Filter filters = 103;
+}
+
+message ListDeploymentEventsResponse {
+  repeated o5.deployer.v1.DeploymentEvent events = 1;
+
+  listify.v1.PageResponse page = 100;
+}
+
+message ListDeploymentsRequest {
+  listify.v1.PageRequest     page    = 100;
+  listify.v1.Search          search  = 101;
+  repeated listify.v1.Sort   sorts   = 102;
+  repeated listify.v1.Filter filters = 103;
+}
+
+message ListDeploymentsResponse {
+  repeated o5.deployer.v1.DeploymentState deployments = 1;
+
+  listify.v1.PageResponse page = 100;
+}


### PR DESCRIPTION
@joshuaslate here's the stubs for the deployer service, this should be the basics of the request response. I've got to make some further adjustments to listify, but intent will likely be that we start with one set of annotations like the filtering and then work just the one set of concerns that way.