### PR TITLE
feat: add dante and o5-auth

### DIFF
--- a/proto/j5.yaml
+++ b/proto/j5.yaml
@@ -4,6 +4,10 @@ registry:
   name: o5
 
 packages:
+  - label: Auth
+    name: o5.auth.v1
+  - label: Dante
+    name: o5.dante.v1
   - label: Deployer
     name: o5.deployer.v1
 options:


### PR DESCRIPTION
This one's not ready yet-- for some reason I get the following when trying to build this from jsonapi:

```
Error running command: building field o5.dante.v1.service.UpdateDeadMessageResponse.message: building field o5.dante.v1.DeadMessageState.current_spec: building field o5.dante.v1.DeadMessageSpec.payload: building field o5.dante.v1.Any.proto: unknown google.protobuf type google.protobuf.Any
```