### PR TITLE
feat: add searches and filters on dead messages

### DIFF
--- a/o5/dante/v1/dead_message.proto
+++ b/o5/dante/v1/dead_message.proto
@@ -77,7 +77,7 @@ enum Urgency {
 }
 
 message InvariantViolation {
-  string description = 1;
+  string description = 1 [(psm.list.v1.field).string.open_text.searching.searchable = true];
   Any error = 2;
   Urgency urgency = 3 [(psm.list.v1.field).enum.filtering.filterable = true];
 }

--- a/o5/dante/v1/dead_message.proto
+++ b/o5/dante/v1/dead_message.proto
@@ -32,8 +32,8 @@ message DeadMessageSpec {
   // The ID used by the underlying messaging infra, can be any format
   string infra_message_id = 2;
 
-  string queue_name = 3;
-  string grpc_name = 4;
+  string queue_name = 3 [(psm.list.v1.field).string.open_text.searching.searchable = true];
+  string grpc_name = 4 [(psm.list.v1.field).string.open_text.searching.searchable = true];
 
   google.protobuf.Timestamp created_at = 5 [
     (buf.validate.field).required = true,
@@ -54,6 +54,8 @@ message DeadMessageSpec {
 
 message Problem {
   oneof type {
+    option (psm.list.v1.oneof).filtering.filterable = true;
+
     InvariantViolation invariant_violation = 1;
     UnhandledError unhandled_error = 2;
   }
@@ -81,13 +83,13 @@ message InvariantViolation {
 }
 
 message UnhandledError {
-  string error = 1;
+  string error = 1 [(psm.list.v1.field).string.open_text.searching.searchable = true];
 }
 
 // Any wraps the well-known any, but encodes messages as JSON in addition
 message Any {
   google.protobuf.Any proto = 1;
-  string json = 2;
+  string json = 2 [(psm.list.v1.field).string.open_text.searching.searchable = true];
 }
 
 message DeadMessageEvent {


### PR DESCRIPTION
@dan9186, the one I'm not sure about here is adding the search to the json string, and how that'd work with the sql implementation. Perhaps I should back that one out? I just figure it may be useful for searching through error payloads for keywords.