### PR TITLE
Split the code source types

### DIFF
--- a/o5/deployer/v1/deployment.proto
+++ b/o5/deployer/v1/deployment.proto
@@ -6,7 +6,6 @@ import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 import "o5/deployer/v1/event.proto";
 import "o5/deployer/v1/pgmigrate.proto";
-import "o5/deployer/v1/stack.proto";
 import "o5/deployer/v1/steps.proto";
 import "psm/list/v1/annotations.proto";
 import "psm/state/v1/annotations.proto";
@@ -29,15 +28,13 @@ message DeploymentState {
     (psm.list.v1.field).string.foreign_key.uuid.filtering.filterable = true
   ];
 
-  google.protobuf.Timestamp created_at = 5 [
-    (psm.list.v1.field).timestamp = {
-      filtering: {filterable: true},
-      sorting: {
-        sortable: true,
-        default_sort: true
-      }
+  google.protobuf.Timestamp created_at = 5 [(psm.list.v1.field).timestamp = {
+    filtering: {filterable: true},
+    sorting: {
+      sortable: true,
+      default_sort: true
     }
-  ];
+  }];
 
   repeated DeploymentStep steps = 10;
 }
@@ -72,6 +69,18 @@ message DeploymentSpec {
   repeated CloudFormationStackParameter parameters = 6;
   repeated string sns_topics = 7;
   CodeSourceType source = 11;
+}
+
+message CodeSourceType {
+  oneof type {
+    Github github = 1;
+  }
+
+  message Github {
+    string owner = 1;
+    string repo = 2;
+    string commit = 3;
+  }
 }
 
 message DeploymentFlags {

--- a/o5/deployer/v1/service/command.proto
+++ b/o5/deployer/v1/service/command.proto
@@ -46,7 +46,7 @@ message TriggerDeploymentRequest {
   // Should be either a UUID, or the environment's full name
   string environment = 2;
 
-  o5.deployer.v1.CodeSourceType source = 3;
+  o5.deployer.v1.SourceTriggerType source = 3;
 
   o5.deployer.v1.DeploymentFlags flags = 4;
 }

--- a/o5/deployer/v1/stack.proto
+++ b/o5/deployer/v1/stack.proto
@@ -12,7 +12,7 @@ option go_package = "github.com/pentops/o5-go/deployer/v1/deployer_pb";
 message StackState {
   option (psm.state.v1.state).name = "stack";
   string stack_id = 1 [(buf.validate.field).string.uuid = true];
-  StackStatus status = 2[(psm.list.v1.field).enum.filtering.filterable = true];
+  StackStatus status = 2 [(psm.list.v1.field).enum.filtering.filterable = true];
 
   optional StackDeployment current_deployment = 3;
 
@@ -45,7 +45,7 @@ message StackState {
 }
 
 message StackConfig {
-  CodeSourceType code_source = 10;
+  SourceTriggerType code_source = 10;
 }
 
 enum StackStatus {
@@ -62,19 +62,15 @@ message StackDeployment {
   string version = 2;
 }
 
-message CodeSourceType {
+message SourceTriggerType {
   oneof type {
-    GitHub git_hub = 1;
+    Github github = 1;
   }
 
-  message GitHub {
+  message Github {
     string owner = 1;
     string repo = 2;
-
-    oneof ref {
-      string branch = 3;
-      string commit = 4;
-    }
+    string branch = 3;
   }
 }
 

--- a/o5/deployer/v1/topic/deployer.proto
+++ b/o5/deployer/v1/topic/deployer.proto
@@ -6,7 +6,6 @@ import "buf/validate/validate.proto";
 import "google/protobuf/empty.proto";
 import "o5/application/v1/application.proto";
 import "o5/deployer/v1/deployment.proto";
-import "o5/deployer/v1/stack.proto";
 import "o5/messaging/v1/annotations.proto";
 
 option go_package = "github.com/pentops/o5-go/deployer/v1/deployer_tpb";


### PR DESCRIPTION
Adjustment for https://github.com/pentops/o5-pb/pull/45
- `gitHub` from `github` breaks the existing data
- The existing type was designed for rules on how to trigger code, the new one is like an audit of where the code came from. There will be overlap, but I think the oneof branch/commit will make things more complex when we have more, or when we support actual wildcards in the branch name (or ref) on the trigger.